### PR TITLE
Parameterized textures

### DIFF
--- a/src/gamma_driver/common/draw.cljs
+++ b/src/gamma_driver/common/draw.cljs
@@ -36,18 +36,17 @@
 
 (defn draw-elements
   ([gl program opts]
-   (.useProgram gl (:program program))
-   (.drawElements
-     gl
-     (draw-modes (:draw-mode opts))
-     (:count opts)
-     (element-types (:type opts))
-     (* ({:unsigned-byte 1 :unsigned-short 2} (:type opts)) (:first opts))))
+     (let [draw-mode (draw-modes (:draw-mode opts))
+           cnt       (:count opts)
+           data-type (element-types (:index-type opts))
+           offset    (* (get {:unsigned-byte 1 :unsigned-short 2} (:index-type opts)) (:first opts))]
+       (.useProgram gl (:program program))
+       (.drawElements gl draw-mode cnt data-type offset)))
   ([gl program opts target]
-    (.bindFramebuffer gl ggl/FRAMEBUFFER (:frame-buffer target))
-    (draw-elements gl program opts)
-    (.bindFramebuffer gl ggl/FRAMEBUFFER nil)
-    target))
+     (.bindFramebuffer gl ggl/FRAMEBUFFER (:frame-buffer target))
+     (draw-elements gl program opts)
+     (.bindFramebuffer gl ggl/FRAMEBUFFER nil)
+     target))
 
 
 

--- a/src/gamma_driver/common/resource.cljs
+++ b/src/gamma_driver/common/resource.cljs
@@ -46,11 +46,11 @@
   (let [buffer (or (:array-buffer spec) (.createBuffer gl))]
     (.bindBuffer gl ggl/ARRAY_BUFFER buffer)
     (.bufferData
-      gl
-      ggl/ARRAY_BUFFER
-      (:data spec)
-      (or ({:static-draw ggl/STATIC_DRAW :dynamic-draw ggl/DYNAMIC_DRAW} (:usage spec))
-          ggl/STATIC_DRAW))
+     gl
+     ggl/ARRAY_BUFFER
+     (:data spec)
+     (or ({:static-draw ggl/STATIC_DRAW :dynamic-draw ggl/DYNAMIC_DRAW} (:usage spec))
+         ggl/STATIC_DRAW))
     (assoc spec :array-buffer buffer)))
 
 

--- a/src/gamma_driver/common/variable.cljs
+++ b/src/gamma_driver/common/variable.cljs
@@ -63,10 +63,63 @@
       nil)
     input))
 
+;; TODO: Should these be shorter?
+;;
+;; TODO: Expose these comments in a way that can be picked up by
+;; tooling and thrown in errors
+(def texture-target
+  {:texture-2d                  ggl/TEXTURE_2D ;;Uses a 2D image.
+   :texture-cube-map-positive-x ggl/TEXTURE_CUBE_MAP_POSITIVE_X ;; Image for the positive X face of the cube map.
+   :texture-cube-map-negative-x ggl/TEXTURE_CUBE_MAP_NEGATIVE_X ;; Image for the negative X face of the cube map.
+   :texture-cube-map-positive-y ggl/TEXTURE_CUBE_MAP_POSITIVE_Y ;; Image for the positive Y face of the cube map.
+   :texture-cube-map-negative-y ggl/TEXTURE_CUBE_MAP_NEGATIVE_Y ;; Image for the negative Y face of the cube map.
+   :texture-cube-map-positive-z ggl/TEXTURE_CUBE_MAP_POSITIVE_Z ;; Image for the positive Z face of the cube map.
+   :texture-cube-map-negative-z ggl/TEXTURE_CUBE_MAP_NEGATIVE_Z}) ;; Image for the negative Z face of the cube map.
+
+(def internal-format
+  {:alpha           ggl/ALPHA           ;; Each element is a single alpha component. The system converts it to floating point, clamped to the range [0, 1], and assembles it into an RGBA element by placing attaching 0.0 to the red, green and blue channels.
+   :luminance       ggl/LUMINANCE       ;; Each element is a single luminance component. The system converts it to floating point value, clamped to the range [0, 1], and assembles it into an RGBA element by placing the luminance value in the red, green and blue channels, and attaching 1.0 to the alpha channel.
+   :luminance-alpha ggl/LUMINANCE_ALPHA ;; Each element is an luminance/alpha double. The systems converts each component to floating point, clamped to the range [0, 1], and assembles them into an RGBA element by placing the luminance value in the red, green and blue channels.
+   :rgb             ggl/RGB             ;; Red, green, and blue channels.
+   :rgba            ggl/RGBA})          ;; Red, green, blue, and alpha (transparency) channels.
+
+(def texture-parameter-names
+  {:texture-min-filter         ggl/TEXTURE_MIN_FILTER ;; A texture filter constant to use when a surface is rendered smaller than the corresponding texture bitmap (such as for distant objects). Initial value is gl.NEAREST_MIPMAP_LINEAR.
+   :texture-mag-filter         ggl/TEXTURE_MAG_FILTER ;; A texture filter constant to use when a surface is rendered larger than the corresponding texture bitmap (such as for close-up objects). Initial value is gl.LINEAR.
+   :texture-wrap-s             ggl/TEXTURE_WRAP_S ;; Sets the wrap parameter for texture coordinate s to either gl.CLAMP or gl.REPEAT. gl.CLAMP causes s coordinates to be clamped to the range [0,1] and is useful for preventing wrapping artifacts when mapping a single image onto an object. gl.REPEAT causes the integer part of the s coordinate to be ignored; WebGL uses only the fractional part, thereby creating a repeating pattern. Border texture elements are accessed only if wrapping is set to gl.CLAMP. Initial value is gl.REPEAT.
+   :texture-wrap-t             ggl/TEXTURE_WRAP_T ;; Sets the wrap parameter for texture coordinate t to either gl.CLAMP or gl.REPEAT. Initial value is gl.REPEAT.
+   :texture-max-anisotropy-ext ggl/TEXTURE_MAX_ANISOTROPY_EXT});; Use anisotropic filtering. You must call getExtension("gl.TEXTURE_MAX_ANISOTROPY_EXT") first to enable. For more info, see Anisotropic filtering.
+
+(def texture-parameter-values
+  {:linear ggl/LINEAR
+   :nearest ggl/NEAREST
+   :mipmap ggl/LINEAR_MIPMAP_NEAREST})
+
+(def pixel-store-parameter-names
+  {:pack-alignment                     ggl/PACK_ALIGNMENT ;; Affects packing of pixel data into memory. The initial param value is 4, but it can be set to 1,2,4, or 8.
+   :unpack-alignment                   ggl/UNPACK_ALIGNMENT ;; Affects unpacking of pixel data from memory. The initial param value is 4, but can be set to 1,2,4, or 8.
+   :unpack-flip-y-webgl                ggl/UNPACK_FLIP_Y_WEBGL ;; Flips the source data along its vertical axis when texImage2D or texSubImage2D are called when param is true. The initial value for param is false.
+   :unpack-premultiply-alpha-webgl     ggl/UNPACK_PREMULTIPLY_ALPHA_WEBGL ;; Multiplies the alpha channel, if it exists, into the other color channels during the data transfer when texImage2D or texSubImage2D are called when param is true. The initial value for param is false.
+   :unpack-colorspace-conversion-webgl ggl/UNPACK_COLORSPACE_CONVERSION_WEBGL});; The browser's default colorspace conversion is applied when texImage2D or texSubImage2D are called with an HTMLImageElement texture data source. The initial value for param is BROWSER_DEFAULT_WEBGL. No colorspace conversion is applied when set to NONE.
+
+;; TODO: Should throw an error if insufficient/incorrectly types
+;; parameters provide
 (defn texture-uniform-input [gl program uniform texture]
-  (let [location (uniform-location gl program uniform)
-        id (:texture-id texture)]
+  (let [location       (uniform-location gl program uniform)
+        id             (:texture-id texture)
+        detail-level   (:detail texture 0)
+        target         (get texture-target (:target texture :texture-2d))
+        format         (get internal-format (:format texture :rgba))
+        texture-params (select-keys texture (keys texture-parameter-names))
+        pixel-params   (select-keys texture (keys pixel-store-parameter-names))]
     (.activeTexture gl (+ ggl/TEXTURE0 id))
-    (.bindTexture gl ggl/TEXTURE_2D (:texture texture))
+    (.bindTexture gl target (:texture texture))
+    ;; Should ggl/UNSIGNED_BYTE be parameterized? Probably...
+    (.texImage2D gl target detail-level format format ggl/UNSIGNED_BYTE (:image texture))
+    (doseq [[k v] texture-params]
+      (.texParameteri gl target (get texture-parameter-names k) (get texture-parameter-values v)))
+    (doseq [[k v] pixel-params]
+      (.pixelStorei gl (get pixel-store-parameter-names k) v))
+    (.generateMipmap gl target)
     (.uniform1i gl location id))
   texture)

--- a/src/gamma_driver/common/variable.cljs
+++ b/src/gamma_driver/common/variable.cljs
@@ -32,6 +32,10 @@
     (.enableVertexAttribArray gl location)
     input))
 
+(defn element-index-input [gl program indices input]
+  (.bindBuffer gl ggl/ELEMENT_ARRAY_BUFFER (:element-array-buffer input))
+  input)
+
 (defn uniform-location [gl program uniform]
   (.getUniformLocation gl (:program program) (:name uniform)))
 

--- a/src/gamma_driver/common/variable.cljs
+++ b/src/gamma_driver/common/variable.cljs
@@ -32,10 +32,6 @@
     (.enableVertexAttribArray gl location)
     input))
 
-(defn element-index-input [gl program indices input]
-  (.bindBuffer gl ggl/ELEMENT_ARRAY_BUFFER (:element-array-buffer input))
-  input)
-
 (defn uniform-location [gl program uniform]
   (.getUniformLocation gl (:program program) (:name uniform)))
 

--- a/src/gamma_driver/drivers/basic.cljs
+++ b/src/gamma_driver/drivers/basic.cljs
@@ -61,6 +61,13 @@
       v/attribute-input
       attribute
       input))
+  (element-index-input [this program attribute input]
+    (input-fn
+      this
+      program
+      v/element-index-input
+      attribute
+      input))
   (texture-uniform-input [this program uniform input]
     (input-fn
       this
@@ -136,6 +143,22 @@
         :element element
         :data (clj->js (flatten [(:data input)]))))))
 
+(defmethod bind* :element-index [driver program element input]
+  (proto/element-index-input
+    driver
+    program
+    element
+    (proto/element-array-buffer
+      driver
+      (let [input (if (map? input) input {:data input})]
+        (assoc input
+          ;; Probably already flattened, but keeping it here for now
+          :data (js/Uint16Array. (clj->js (flatten (:data input))))
+          :usage :static-draw
+          :element element
+          :test :work
+          :count (count (:data input)))))))
+
 
 (comment
   (defmethod bind* :texture-uniform [driver program variable input]
@@ -181,9 +204,7 @@
           (:count v)))
       (@(:input-state driver) program))))
 
-
-
-(defn draw-program [driver program data]
+(defn draw-program [driver program data & [opts]]
   (bind driver program data)
   (if (not (input-complete? driver program))
     (throw (js/Error. "Program inputs are incomplete."))
@@ -191,9 +212,24 @@
       driver
       program
       ;; should supply below as an arg, with defaults
-      {:draw-mode :triangles
+      {:draw-mode (:draw-mode opts :triangles)
        :first 0
        :count (draw-count driver program)})))
+
+(defn draw-elements [driver program data opts]
+  (bind driver program data)
+  (if (not (input-complete? driver program))
+    (throw (js/Error. "Program inputs are incomplete."))
+    (proto/draw-elements
+     driver
+     program
+     ;; should supply below as an arg, with defaults
+     {:draw-mode (:draw-mode opts :triangles)
+      :first 0
+      ;; Should we just throw an error if :index-type isn't specified,
+      ;; rather than default to :unsigned-short?  Seems kinder.
+      :index-type (:draw-type opts :unsigned-short)
+      :count (:count opts)})))
 
 
 

--- a/src/gamma_driver/drivers/basic.cljs
+++ b/src/gamma_driver/drivers/basic.cljs
@@ -160,18 +160,17 @@
           :count (count (:data input)))))))
 
 
-(comment
-  (defmethod bind* :texture-uniform [driver program variable input]
-   (proto/texture-uniform-input
-     driver
-     program
-     variable
-     (proto/texture
-       driver
-       ;; not sure if this is the right logic
-       (if (map? (:data input))
-         (:data input)
-         {:image (:data input) :texture-id 0})))))
+(defmethod bind* :texture-uniform [driver program variable input]
+  (proto/texture-uniform-input
+   driver
+   program
+   variable
+   (proto/texture
+    driver
+    ;; not sure if this is the right logic
+    (if (map? (:data input))
+      (:data input)
+      {:image (:data input) :texture-id 0}))))
 
 (comment
   (defmethod bind* :element-array [driver program variable input]

--- a/src/gamma_driver/drivers/basic.cljs
+++ b/src/gamma_driver/drivers/basic.cljs
@@ -61,13 +61,6 @@
       v/attribute-input
       attribute
       input))
-  (element-index-input [this program attribute input]
-    (input-fn
-      this
-      program
-      v/element-index-input
-      attribute
-      input))
   (texture-uniform-input [this program uniform input]
     (input-fn
       this
@@ -144,21 +137,16 @@
         :data (clj->js (flatten [(:data input)]))))))
 
 (defmethod bind* :element-index [driver program element input]
-  (proto/element-index-input
-    driver
-    program
-    element
-    (proto/element-array-buffer
-      driver
-      (let [input (if (map? input) input {:data input})]
-        (assoc input
-          ;; Probably already flattened, but keeping it here for now
-          :data (js/Uint16Array. (clj->js (flatten (:data input))))
-          :usage :static-draw
-          :element element
-          :test :work
-          :count (count (:data input)))))))
-
+  (let [spec (let [input (if (map? input)
+                           input
+                           {:data input})]
+               (assoc input
+                 ;; Probably already flattened, but keeping it here for now
+                 :data (js/Uint16Array. (clj->js (flatten (:data input))))
+                 :usage :static-draw
+                 :element element
+                 :count (count (:data input))))]
+    (proto/element-array-buffer driver spec)))
 
 (defmethod bind* :texture-uniform [driver program variable input]
   (proto/texture-uniform-input
@@ -219,16 +207,19 @@
   (bind driver program data)
   (if (not (input-complete? driver program))
     (throw (js/Error. "Program inputs are incomplete."))
-    (proto/draw-elements
-     driver
-     program
-     ;; should supply below as an arg, with defaults
-     {:draw-mode (:draw-mode opts :triangles)
-      :first 0
-      ;; Should we just throw an error if :index-type isn't specified,
-      ;; rather than default to :unsigned-short?  Seems kinder.
-      :index-type (:draw-type opts :unsigned-short)
-      :count (:count opts)})))
+    (let [index-type (-> data
+                         (get {:tag :element-index})
+                         (:type :unsigned-short))]
+      (proto/draw-elements
+       driver
+       program
+       ;; should supply below as an arg, with defaults
+       {:draw-mode (:draw-mode opts :triangles)
+        :first 0
+        ;; Should we just throw an error if :index-type isn't specified,
+        ;; rather than default to :unsigned-short?  Seems kinder.
+        :index-type index-type
+        :count (:count opts)}))))
 
 
 

--- a/src/gamma_driver/drivers/basic.cljs
+++ b/src/gamma_driver/drivers/basic.cljs
@@ -157,9 +157,8 @@
 
 (defn bind [driver program data]
   (.useProgram (:gl driver) (:program program))
-  (dorun
-    (map (fn [[k v]] (bind* driver program k v))
-         data)))
+  (doseq [[k v] data]
+    (bind* driver program k v)))
 
 (defn program-inputs-state [driver program]
   (let [s (@(:input-state driver) program)]

--- a/src/gamma_driver/protocols.cljs
+++ b/src/gamma_driver/protocols.cljs
@@ -16,7 +16,6 @@
 
 (defprotocol WebGLVariableDriver
   (attribute-input [this program attribute input])
-  (element-index-input [this program attribute input])
   (texture-uniform-input [this program uniform input])
   (uniform-input [this program uniform input]))
 

--- a/src/gamma_driver/protocols.cljs
+++ b/src/gamma_driver/protocols.cljs
@@ -16,6 +16,7 @@
 
 (defprotocol WebGLVariableDriver
   (attribute-input [this program attribute input])
+  (element-index-input [this program attribute input])
   (texture-uniform-input [this program uniform input])
   (uniform-input [this program uniform input]))
 


### PR DESCRIPTION
Exposes textures so they can be used. Configuration seems best done at load time, e.g.: https://gist.github.com/sgrove/ddac13456296c7154625#file-lesson_06-cljs-L217

Relies on #1 
