### PR TITLE
draw-elements bug fix

### DIFF
--- a/src/gamma_driver/common/draw.cljs
+++ b/src/gamma_driver/common/draw.cljs
@@ -37,12 +37,15 @@
 
 (defn draw-elements
   ([gl program opts]
-     (let [draw-mode (draw-modes (:draw-mode opts))
-           cnt       (:count opts)
-           data-type (element-types (:index-type opts))
-           offset    (* (get {:unsigned-byte 1 :unsigned-short 2} (:index-type opts)) (:first opts))]
-       (.useProgram gl (:program program))
-       (.drawElements gl draw-mode cnt data-type offset)))
+   (let [draw-mode (let [dm (:draw-mode opts)]
+                     (if (integer? dm)
+                       dm
+                       (draw-modes (:draw-mode opts))))
+         cnt       (:count opts)
+         data-type (element-types (:index-type opts) ggl/UNSIGNED_SHORT)
+         offset    (* (get {:unsigned-byte 1 :unsigned-short 2} (:index-type opts)) (:first opts))]
+     (.useProgram gl (:program program))
+     (.drawElements gl draw-mode cnt data-type offset)))
   ([gl program opts target]
      (.bindFramebuffer gl ggl/FRAMEBUFFER (:frame-buffer target))
      (draw-elements gl program opts)

--- a/src/gamma_driver/common/variable.cljs
+++ b/src/gamma_driver/common/variable.cljs
@@ -8,7 +8,7 @@
 
 
 (defn default-layout [attribute]
-  {:normalized false
+  {:normalized? false
    :size ({:float 1 :vec2 2 :vec3 3 :vec4 4}
            (:type attribute))
    :type ggl/FLOAT

--- a/src/gamma_driver/drivers/basic.cljs
+++ b/src/gamma_driver/drivers/basic.cljs
@@ -45,8 +45,8 @@
           (map #(vector % (s %)) (:inputs program)))))
 
 (defn input-complete? [driver program]
-  (let [state (@(:input-state driver) program)
-        inputs (:inputs program)]
+  (let [state   (@(:input-state driver) program)
+        inputs  (:inputs program)]
     (not-any? nil? (map state inputs))))
 ;; would like return value to indicate which inputs are not filled in?
 
@@ -83,7 +83,7 @@
     (if (not (input-complete? driver program))
      (throw (js/Error. "Program inputs are incomplete."))
      (gd/draw-elements
-       driver
+      (gdp/gl driver)
        program
        ;; should supply below as an arg, with defaults
        {:draw-mode  (:draw-mode opts :triangles)

--- a/src/gamma_driver/impl/bind.cljs
+++ b/src/gamma_driver/impl/bind.cljs
@@ -25,19 +25,19 @@
      program
      element
      (array-buffer
-       driver
-       (let [input (if (map? input) input {:data input})
-             data (:data input)]
-         (assoc input
-           :data (if (.-buffer data)
-                   data
-                   (js/Float32Array. (clj->js (flatten data))))
-           :usage :static-draw
-           :element element
-           :count (if-let [c (:count input)]
-                    c
-                    (if (seqable? data)
-                      (count data)))))))))
+      driver
+      (let [input (if (map? input) input {:data input})
+            data  (:data input)]
+        (assoc input
+               :data (if (.-length data)
+                       data
+                       (js/Float32Array. (clj->js (flatten data))))
+               :usage :static-draw
+               :element element
+               :count (if-let [c (:count input)]
+                        c
+                        (if (seqable? data)
+                          (count data)))))))))
 
 (defmethod bind* :uniform [fns driver program element input]
   (let [{:keys [bind-uniform]} fns]
@@ -57,10 +57,14 @@
                             {:data input})]
                 (assoc input
                   ;; Probably already flattened, but keeping it here for now
-                  :data (js/Uint16Array. (clj->js (flatten (:data input))))
+                  :data  (if (.-buffer (:data input))
+                           (:data input)
+                           (js/Uint16Array. (clj->js (flatten (:data input)))))
                   :usage :static-draw
                   :element element
-                  :count (count (:data input))))]
+                  :count (if-let [c (:count input)]
+                           c
+                           (count (:data input)))))]
      (element-array-buffer driver spec))))
 
 

--- a/src/gamma_driver/impl/resource.cljs
+++ b/src/gamma_driver/impl/resource.cljs
@@ -107,12 +107,12 @@
 
 
 (def texture-filter-constants
-  {:linear ggl/LINEAR
-   :nearest ggl/NEAREST
+  {:linear                 ggl/LINEAR
+   :nearest                ggl/NEAREST
    :nearest-mipmap-nearest ggl/NEAREST_MIPMAP_NEAREST
-   :linear-mipmap-nearest ggl/LINEAR_MIPMAP_NEAREST
-   :nearest-mipmap-linear ggl/NEAREST_MIPMAP_LINEAR
-   :linear-mipmap-linear ggl/LINEAR_MIPMAP_LINEAR})
+   :linear-mipmap-nearest  ggl/LINEAR_MIPMAP_NEAREST
+   :nearest-mipmap-linear  ggl/NEAREST_MIPMAP_LINEAR
+   :linear-mipmap-linear   ggl/LINEAR_MIPMAP_LINEAR})
 
 (defn- texture-filter [gl spec]
   (let [{:keys [min mag]} spec]
@@ -192,7 +192,7 @@
 
 
 (defn texture [gl spec]
-  ;(println spec)
+                                        ;(println spec)
   (if (:texture spec)
     spec
     (let [tex (.createTexture gl)

--- a/src/gamma_driver/impl/variable.cljs
+++ b/src/gamma_driver/impl/variable.cljs
@@ -8,7 +8,7 @@
 
 
 (defn default-layout [attribute]
-  {:normalized false
+  {:normalized? false
    :size ({:float 1 :vec2 2 :vec3 3 :vec4 4}
            (:type attribute))
    :type ggl/FLOAT


### PR DESCRIPTION
Fixes a bug 1.) where `draw-elements` would blow the stack 2.) the data/count of element index wasn't being properly passed through if it was e.g. ArrayBuffer data 3.) `normalized` => `normalized?`

Best view it with ws diffing disabled, sorry about that.
