### PR TITLE
Initial pass at texture-cube-map support

### DIFF
--- a/src/gamma_driver/impl/bind.cljs
+++ b/src/gamma_driver/impl/bind.cljs
@@ -6,7 +6,8 @@
       (= :attribute (:storage element)) :attribute
       (and
         (= :uniform (:storage element))
-        (= :sampler2D (:type element))) :texture-uniform
+        (or (= :sampler2D (:type element))
+            (= :samplerCube (:type element)))) :texture-uniform
       (= :uniform (:storage element)) :uniform)
     (cond
       (= :element-index (:tag element)) :element-index

--- a/src/gamma_driver/impl/variable.cljs
+++ b/src/gamma_driver/impl/variable.cljs
@@ -67,8 +67,9 @@
 
 (defn bind-texture-uniform [gl program uniform texture]
   (let [location (uniform-location gl program uniform)
-        id (:texture-id texture)]
+        id       (:texture-id texture)
+        target   (:target texture)]
     (.activeTexture gl (+ ggl/TEXTURE0 id))
-    (.bindTexture gl ggl/TEXTURE_2D (:texture texture))
+    (.bindTexture gl target (:texture texture))
     (.uniform1i gl location id))
   texture)


### PR DESCRIPTION
It's a bit mess (not in love with this https://github.com/kovasb/gamma-driver/compare/kovasb:master...sgrove:texture-cube-map?expand=1#diff-4ff6e111ddce8b412161f31db96c1627R213) but it works. Feel free to reject, clean up, or implement separately.
