### PR TITLE
Draw element fix

### DIFF
--- a/src/gamma_driver/api.cljs
+++ b/src/gamma_driver/api.cljs
@@ -83,6 +83,13 @@
     (gdp/bind-attribute this program attribute array-buffer-model)
     (variable/bind-attribute this program attribute array-buffer-model)))
 
+(defn bind-element-array
+  "Binds element variable to data in element-array-buffer-model."
+  [this program element-array element-array-buffer-model]
+  (if (satisfies? gdp/IBindVariable this)
+    (gdp/bind-element-array this program element-array element-array-buffer-model)
+    (variable/bind-element-index this program element-array element-array-buffer-model)))
+
 (defn bind-texture-uniform
   "Binds texture uniform variable (sampler2D) to data in texture-model."
   [this program uniform texture-model]
@@ -106,13 +113,14 @@
     (gdp/bind this program spec)
     (bind/bind
       ;; need to pass these in to avoid cyclic dependency
-      {:program program
-       :array-buffer array-buffer
-       :element-array-buffer element-array-buffer
-       :texture texture
-       :bind-attribute       bind-attribute
-       :bind-texture-uniform bind-texture-uniform
-       :bind-uniform         bind-uniform}
+     {:program              program
+      :array-buffer         array-buffer
+      :element-array-buffer element-array-buffer
+      :texture              texture
+      :bind-element-array   bind-element-array
+      :bind-attribute       bind-attribute
+      :bind-texture-uniform bind-texture-uniform
+      :bind-uniform         bind-uniform}
       this prog spec)))
 
 

--- a/src/gamma_driver/drivers/basic.cljs
+++ b/src/gamma_driver/drivers/basic.cljs
@@ -136,6 +136,13 @@
       gd/bind-attribute
       attribute
       input))
+  (bind-element-array [this program element-array input]
+    (input-fn
+      this
+      program
+      gd/bind-element-array
+      element-array
+      input))
   (bind-texture-uniform [this program uniform input]
     (input-fn
       this

--- a/src/gamma_driver/drivers/basic.cljs
+++ b/src/gamma_driver/drivers/basic.cljs
@@ -82,7 +82,7 @@
   ([driver program opts target]
    (if (not (input-complete? driver program))
      (throw (js/Error. "Program inputs are incomplete."))
-     (if [c (if-let [c (:count opts)] c (draw-count driver program))]
+     (let [c (get opts :count (draw-count driver program))]
        (gd/draw-arrays
         (gdp/gl driver)
         program

--- a/src/gamma_driver/impl/bind.cljs
+++ b/src/gamma_driver/impl/bind.cljs
@@ -52,21 +52,28 @@
          :data (clj->js (flatten [(:data input)])))))))
 
 (defmethod bind* :element-index [fns driver program element input]
-  (let [{:keys [element-array-buffer]} fns]
-    (let [spec (let [input (if (map? input)
-                            input
-                            {:data input})]
-                (assoc input
-                  ;; Probably already flattened, but keeping it here for now
-                  :data  (if (.-buffer (:data input))
-                           (:data input)
-                           (js/Uint16Array. (clj->js (flatten (:data input)))))
-                  :usage :static-draw
-                  :element element
-                  :count (if-let [c (:count input)]
-                           c
-                           (count (:data input)))))]
-     (element-array-buffer driver spec))))
+  (let [{:keys [bind-element-array element-array-buffer]} fns]
+    (bind-element-array
+     driver
+     program
+     element
+     (element-array-buffer
+      driver
+      (let [spec (let [data  (:data input)
+                       input (if (map? input)
+                               input
+                               {:data input})]
+                   (assoc input
+                          ;; Probably already flattened, but keeping it here for now
+                          :data  (if (.-buffer (:data input))
+                                   (:data input)
+                                   (js/Uint16Array. (clj->js (flatten (:data input)))))
+                          :usage :static-draw
+                          :element element
+                          :count (if-let [c (:count input)]
+                                   c
+                                   (count (:data input)))))]
+        spec)))))
 
 
 (defmethod bind* :texture-uniform [fns driver program variable input]

--- a/src/gamma_driver/impl/bind.cljs
+++ b/src/gamma_driver/impl/bind.cljs
@@ -6,7 +6,8 @@
       (= :attribute (:storage element)) :attribute
       (and
         (= :uniform (:storage element))
-        (= :sampler2D (:type element))) :texture-uniform
+        (or (= :sampler2D (:type element))
+            (= :samplerCube (:type element)))) :texture-uniform
       (= :uniform (:storage element)) :uniform)
     (cond
       (= :element-index (:tag element)) :element-index

--- a/src/gamma_driver/impl/variable.cljs
+++ b/src/gamma_driver/impl/variable.cljs
@@ -32,7 +32,7 @@
     (.enableVertexAttribArray gl location)
     input))
 
-(defn element-index-input [gl program indices input]
+(defn bind-element-index [gl program indices input]
   (.bindBuffer gl ggl/ELEMENT_ARRAY_BUFFER (:element-array-buffer input))
   input)
 

--- a/src/gamma_driver/impl/variable.cljs
+++ b/src/gamma_driver/impl/variable.cljs
@@ -67,8 +67,9 @@
 
 (defn bind-texture-uniform [gl program uniform texture]
   (let [location (uniform-location gl program uniform)
-        id (:texture-id texture)]
+        id       (:texture-id texture)
+        target   (:target texture)]
     (.activeTexture gl (+ ggl/TEXTURE0 id))
-    (.bindTexture gl ggl/TEXTURE_2D (:texture texture))
+    (.bindTexture gl target (:texture texture))
     (.uniform1i gl location id))
   texture)

--- a/src/gamma_driver/protocols.cljs
+++ b/src/gamma_driver/protocols.cljs
@@ -16,6 +16,7 @@
 
 (defprotocol IBindVariable
   (bind-attribute [this program attribute input])
+  (bind-element-array [this program element-array input])
   (bind-texture-uniform [this program uniform input])
   (bind-uniform [this program uniform input]))
 


### PR DESCRIPTION
This one was very painful to track down - the first frame would render properly, but then subsequent frames would GL_ERROR out, saying that the element array buffer referenced indices outside of attribute 0 (or something to that effect).

This is another case of a "happy accident" where a scene will render based off of some previous state, that turns into a very unhappy accident when subsequent draw calls don't have the state incidentally set up properly.

I'm also thinking about testing a bit - perhaps there should be a few high-level sanity checks to run through? Should be able to put together a test suite to exercise draw-arrays/elements with textures, etc. kinda-sorta easily.
