### PR TITLE
Check if data is already pure js before converting

### DIFF
--- a/src/gamma_driver/impl/bind.cljs
+++ b/src/gamma_driver/impl/bind.cljs
@@ -44,10 +44,13 @@
      driver
      program
      element
-     (let [input (if (map? input) input {:data input})]
+     (let [input (if (map? input) input {:data input})
+           data (:data input)]
        (assoc input
          :element element
-         :data (clj->js (flatten [(:data input)])))))))
+         :data (if (array? data)
+                 data
+                 (clj->js (flatten [data]))))))))
 
 (defmethod bind* :element-index [fns driver program element input]
   (let [{:keys [bind-element-array element-array-buffer]} fns]


### PR DESCRIPTION
Checks if data is already pure js before converting it with clj->js.

@sgrove was showing me around [gamma-playground](https://github.com/sgrove/gamma-playground) and we did some profiling. Calling clj->js in bind\* :uniform was taking up something like 5% of the cpu runtime.

This lets the caller optimize by passing in pure js arrays.
