### PR TITLE
Be more descriptive when programs are incomplete

### DIFF
--- a/src/gamma_driver/drivers/basic.cljs
+++ b/src/gamma_driver/drivers/basic.cljs
@@ -45,7 +45,7 @@
 (defn input-incomplete? [driver program]
   (let [state  (@(:input-state driver) program)
         inputs (:inputs program)]
-    (if (some nil? (map state inputs))
+    (if (some nil? (map #(get state %) inputs))
       ;; We're going to bail at this point anyway, so let's spend some
       ;; extra time extracting what inputs were incomplete
       (remove (fn [input] (get state input)) inputs)


### PR DESCRIPTION
Improves two error messages:
1. When missing program inputs, previously the message simply said, `Program input not complete`. This was pretty difficult to debug with lots of programs with lots of inputs - the new error message looks like `Program ':lession-01-simple' inputs are incomplete.(["uPMatrix" :mat4] ["uMVMatrix" :mat4] ["aVertexPosition" :vec3])`, and shouldn't incur any performance penalty.
2. When `state` is `nil` inside `gamma-driver.drivers.basic/input-incomplete?`, you would previously get e.g
   `Uncaught TypeError: Cannot read property 'cljs$core$IFn$_invoke$arity$1' of null` - now you'll get the same message above

Relies (partially, for the program name) on https://github.com/kovasb/gamma/pull/14

It would possibly also be quite kind to `console.warn` (outside of production mode) when a program is passed in without an `:id`, so the developer is aware that one can be provided and that it will help with debugging.
